### PR TITLE
로그인 회원 id, 이름 조회 메소드 구현

### DIFF
--- a/src/main/java/com/flab/football/controller/UserController.java
+++ b/src/main/java/com/flab/football/controller/UserController.java
@@ -7,8 +7,6 @@ import com.flab.football.domain.User;
 import com.flab.football.service.security.SecurityService;
 import com.flab.football.service.user.UserService;
 import com.flab.football.util.SecurityUtil;
-import java.lang.management.OperatingSystemMXBean;
-import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +15,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -108,7 +105,11 @@ public class UserController {
   @GetMapping("/login/check")
   public ResponseDto logInCheck() {
 
-    SecurityUtil.getCurrentEmail().ifPresent(System.out::println);
+    log.info("userEmail from util = {}", SecurityUtil.getCurrentEmail().get());
+
+    log.info("userId from token = {}", securityService.getCurrentUserId());
+
+    log.info("userName from token = {}", securityService.getCurrentUserName());
 
     return new ResponseDto(true, null, "로그인 체크", null);
 

--- a/src/main/java/com/flab/football/controller/UserController.java
+++ b/src/main/java/com/flab/football/controller/UserController.java
@@ -3,9 +3,11 @@ package com.flab.football.controller;
 import com.flab.football.controller.request.LogInRequest;
 import com.flab.football.controller.request.SignUpRequest;
 import com.flab.football.controller.response.ResponseDto;
+import com.flab.football.domain.User;
 import com.flab.football.service.security.SecurityService;
 import com.flab.football.service.user.UserService;
 import com.flab.football.util.SecurityUtil;
+import java.lang.management.OperatingSystemMXBean;
 import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -74,11 +76,13 @@ public class UserController {
   @PostMapping("/login")
   public ResponseDto logIn(@Valid @RequestBody LogInRequest request) {
 
-    if (userService.checkValidEmailAndPw(request.getEmail(), request.getPassword())) {
+    User user = userService.findByEmailAndPw(request.getEmail(), request.getPassword());
 
-      securityService.logIn(request.getEmail(), request.getPassword());
-
-    }
+    securityService.logIn(
+        LogInRequest.toCommand(
+          request.getEmail(), request.getPassword(), user.getId(), user.getName()
+      )
+    );
 
     return new ResponseDto(true, null, "로그인 성공", null);
 

--- a/src/main/java/com/flab/football/controller/request/LogInRequest.java
+++ b/src/main/java/com/flab/football/controller/request/LogInRequest.java
@@ -1,5 +1,7 @@
 package com.flab.football.controller.request;
 
+import com.flab.football.domain.User;
+import com.flab.football.service.user.command.LogInCommand;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +14,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LogInRequest {
+
   private String email;
   private String password;
+
+  /**
+   * Command 객체로 변경하기 위한 팩토리 메소드.
+   */
+
+  public static LogInCommand toCommand(String email, String password, int userId, String name) {
+
+    return new LogInCommand(email, password, userId, name);
+
+  }
+
 }

--- a/src/main/java/com/flab/football/service/security/JwtSecurityService.java
+++ b/src/main/java/com/flab/football/service/security/JwtSecurityService.java
@@ -3,9 +3,11 @@ package com.flab.football.service.security;
 import static com.flab.football.util.SecurityUtil.AUTHORIZATION_HEADER;
 
 import com.flab.football.service.security.jwt.TokenProvider;
+import com.flab.football.service.user.command.LogInCommand;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtSecurityService implements SecurityService {
@@ -21,15 +24,15 @@ public class JwtSecurityService implements SecurityService {
   private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
   @Override
-  public void logIn(String email, String password) {
+  public void logIn(LogInCommand command) {
 
     UsernamePasswordAuthenticationToken authenticationToken =
-        new UsernamePasswordAuthenticationToken(email, password);
+        new UsernamePasswordAuthenticationToken(command.getEmail(), command.getPassword());
 
     Authentication authentication = authenticationManagerBuilder.getObject()
         .authenticate(authenticationToken);
 
-    String jwt = tokenProvider.createToken(authentication);
+    String jwt = tokenProvider.createToken(authentication, command.getUserId(), command.getName());
 
     HttpServletResponse response = getCurrentResponse();
 

--- a/src/main/java/com/flab/football/service/security/JwtSecurityService.java
+++ b/src/main/java/com/flab/football/service/security/JwtSecurityService.java
@@ -4,7 +4,6 @@ import static com.flab.football.util.SecurityUtil.AUTHORIZATION_HEADER;
 
 import com.flab.football.service.security.jwt.TokenProvider;
 import com.flab.football.service.user.command.LogInCommand;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,9 +33,13 @@ public class JwtSecurityService implements SecurityService {
 
     String jwt = tokenProvider.createToken(authentication, command.getUserId(), command.getName());
 
-    HttpServletResponse response = getCurrentResponse();
+    ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder
+        .currentRequestAttributes();
+
+    HttpServletResponse response = attributes.getResponse();
 
     response.setHeader(AUTHORIZATION_HEADER, "Bearer " + jwt);
+
 
   }
 
@@ -45,28 +48,18 @@ public class JwtSecurityService implements SecurityService {
 
   }
 
+
   @Override
   public int getCurrentUserId() {
-    
-    return 0;
-    
-  }
 
-  private ServletRequestAttributes getRequestAttributes() {
-
-    return (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+    return tokenProvider.getCurrentUserId();
 
   }
 
-  private HttpServletRequest getCurrentRequest() {
+  @Override
+  public String getCurrentUserName() {
 
-    return getRequestAttributes().getRequest();
-
-  }
-
-  private HttpServletResponse getCurrentResponse() {
-
-    return getRequestAttributes().getResponse();
+    return tokenProvider.getCurrentUserName();
 
   }
 

--- a/src/main/java/com/flab/football/service/security/SecurityService.java
+++ b/src/main/java/com/flab/football/service/security/SecurityService.java
@@ -1,12 +1,14 @@
 package com.flab.football.service.security;
 
+import com.flab.football.service.user.command.LogInCommand;
+
 /**
  * SecurityService 인터페이스.
  */
 
 public interface SecurityService {
 
-  void logIn(String email, String password);
+  void logIn(LogInCommand command);
 
   void logOut();
 

--- a/src/main/java/com/flab/football/service/security/SecurityService.java
+++ b/src/main/java/com/flab/football/service/security/SecurityService.java
@@ -14,4 +14,6 @@ public interface SecurityService {
 
   int getCurrentUserId();
 
+  String getCurrentUserName();
+
 }

--- a/src/main/java/com/flab/football/service/security/jwt/TokenProvider.java
+++ b/src/main/java/com/flab/football/service/security/jwt/TokenProvider.java
@@ -63,7 +63,7 @@ public class TokenProvider implements InitializingBean {
    * Authentication 객체의 권한정보를 이용해서 토큰을 생성하는 createToken 메소드 추가.
    */
 
-  public String createToken(Authentication authentication) {
+  public String createToken(Authentication authentication, int userId, String userName) {
 
     String authorities = authentication.getAuthorities()
         .stream()
@@ -73,12 +73,19 @@ public class TokenProvider implements InitializingBean {
     long now = (new Date()).getTime();
     Date validity = new Date(now + this.tokenValidityInMilliseconds);
 
-    return Jwts.builder()
+    Claims claims = Jwts.claims()
         .setSubject(authentication.getName())
-        .claim(AUTHORITIES_KEY, authorities)
+        .setExpiration(validity);
+
+    claims.put(AUTHORITIES_KEY, authorities);
+    claims.put("id", userId);
+    claims.put("name", userName);
+
+    return Jwts.builder()
+        .setClaims(claims)
         .signWith(key, SignatureAlgorithm.HS512)
-        .setExpiration(validity)
         .compact();
+
   }
 
   /**

--- a/src/main/java/com/flab/football/service/user/command/LogInCommand.java
+++ b/src/main/java/com/flab/football/service/user/command/LogInCommand.java
@@ -1,0 +1,15 @@
+package com.flab.football.service.user.command;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LogInCommand {
+
+  private String email;
+  private String password;
+  private int userId;
+  private String name;
+
+}

--- a/src/main/java/com/flab/football/util/SecurityUtil.java
+++ b/src/main/java/com/flab/football/util/SecurityUtil.java
@@ -17,7 +17,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class SecurityUtil {
 
   public static final String AUTHORIZATION_HEADER = "Authorization";
-
+  public static final String AUTHORITIES_KEY = "auth";
+  public static final String ID_KEY = "id";
+  public static final String NAME_KEY = "name";
   /**
    * user Email 조회를 위한 메소드.
    */


### PR DESCRIPTION
로그인한 회원이 보낸 request 객체에 담겨오는 토큰에 id, name에 대한 정보를 추가로 저장하고 해당 정보를 조회하는 메소드를 구현했습니다!