### PR TITLE
웹소켓 서버 HealthCheck 기능 구현

### DIFF
--- a/src/main/java/com/flab/football/FootballApplication.java
+++ b/src/main/java/com/flab/football/FootballApplication.java
@@ -2,11 +2,13 @@ package com.flab.football;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * 어플리케이션 실행 클래스.
  */
 
+@EnableScheduling
 @SpringBootApplication
 public class FootballApplication {
   public static void main(String[] args) {

--- a/src/main/java/com/flab/football/config/SecurityConfig.java
+++ b/src/main/java/com/flab/football/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     web
         .ignoring()
         .antMatchers("/chat/health/check")
-        .antMatchers("/ws/send/message");
+        .antMatchers("/ws/send/message")
+        .antMatchers("/ws/connect");
 
   }
 

--- a/src/main/java/com/flab/football/config/SecurityConfig.java
+++ b/src/main/java/com/flab/football/config/SecurityConfig.java
@@ -44,7 +44,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Override
   public void configure(WebSecurity web) throws Exception {
     web
-        .ignoring().antMatchers("/ws/send/message");
+        .ignoring()
+        .antMatchers("/chat/health/check")
+        .antMatchers("/ws/send/message");
+
   }
 
   /**

--- a/src/main/java/com/flab/football/controller/ChatController.java
+++ b/src/main/java/com/flab/football/controller/ChatController.java
@@ -6,13 +6,10 @@ import com.flab.football.controller.request.InviteParticipantsRequest;
 import com.flab.football.controller.request.SendMessageRequest;
 import com.flab.football.controller.response.ResponseDto;
 import com.flab.football.service.chat.ChatService;
-import com.flab.football.service.redis.RedisService;
 import com.flab.football.service.security.SecurityService;
-import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,7 +17,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * 채팅 기능 관련 API 선언이 되어있는 컨트롤러.
@@ -36,6 +32,10 @@ public class ChatController {
 
   private final SecurityService securityService;
 
+  /**
+   * 웹 소켓 서버에 대한 healthCheck 값을 받기 위한 API.
+   */
+
   @PostMapping("/health/check")
   public ResponseDto healthCheck(@RequestBody HealthCheckRequest request) {
 
@@ -46,11 +46,26 @@ public class ChatController {
         request.getHeartBeatTime()
     );
 
-    // 가장 연결 수가 적은 서버를 리턴해주는 로직도 구현해야 한다.
-
     return new ResponseDto(true, null, "헬스 체크 완료", null);
 
   }
+
+  /**
+   * 새로운 사용자를 웹소켓 서버에 연결시켜주는 API
+   * req 포함 내용 ->
+   */
+
+  @GetMapping("/connect")
+  public ResponseDto connectWebSocket() {
+
+    // 가장 커넥션 수가 적은 서버 주소로 웹소켓 연결 요청을 보낸다.
+    // user 정보를 보내줘야 할 수도 있겠다.
+    chatService.connectUserToWebSocket();
+
+    return new ResponseDto(true, null, "웹 소켓 연결 완료.", null);
+
+  }
+
 
   /**
    * 새로운 채팅방 생성 API.

--- a/src/main/java/com/flab/football/controller/ChatController.java
+++ b/src/main/java/com/flab/football/controller/ChatController.java
@@ -5,6 +5,7 @@ import com.flab.football.controller.request.HealthCheckRequest;
 import com.flab.football.controller.request.InviteParticipantsRequest;
 import com.flab.football.controller.request.SendMessageRequest;
 import com.flab.football.controller.response.ResponseDto;
+import com.flab.football.controller.response.data.FindPossibleConnectServerResponse;
 import com.flab.football.service.chat.ChatService;
 import com.flab.football.service.security.SecurityService;
 import javax.validation.Valid;
@@ -51,18 +52,21 @@ public class ChatController {
   }
 
   /**
-   * 새로운 사용자를 웹소켓 서버에 연결시켜주는 API
-   * req 포함 내용 ->
+   * 새로운 사용자를 웹소켓 서버 주소를 탐색하는 API.
+   *
    */
 
   @GetMapping("/connect")
-  public ResponseDto connectWebSocket() {
+  public ResponseDto findPossibleConnectServerAddress() {
 
-    // 가장 커넥션 수가 적은 서버 주소로 웹소켓 연결 요청을 보낸다.
-    // user 정보를 보내줘야 할 수도 있겠다.
-    chatService.connectUserToWebSocket();
+    String address = chatService.findPossibleConnectServerAddress();
 
-    return new ResponseDto(true, null, "웹 소켓 연결 완료.", null);
+    return new ResponseDto(
+        true,
+        new FindPossibleConnectServerResponse(address),
+        "웹 소켓 주소 전송 완료.",
+        null
+    );
 
   }
 
@@ -121,7 +125,7 @@ public class ChatController {
     // 아래 로직이 모두 ChatService.sendMessage() 로 가야한다.
     chatService.sendMessage(request.getChannelId(), sendUserId, request.getContent());
 
-    return new ResponseDto<>(true, null, "분류 완료.", null);
+    return new ResponseDto<>(true, null, "메세지 전송 완료", null);
 
   }
 

--- a/src/main/java/com/flab/football/controller/ChatController.java
+++ b/src/main/java/com/flab/football/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.flab.football.controller;
 
 import com.flab.football.controller.request.CreateChannelRequest;
+import com.flab.football.controller.request.HealthCheckRequest;
 import com.flab.football.controller.request.InviteParticipantsRequest;
 import com.flab.football.controller.request.SendMessageRequest;
 import com.flab.football.controller.response.ResponseDto;
@@ -34,6 +35,22 @@ public class ChatController {
   private final ChatService chatService;
 
   private final SecurityService securityService;
+
+  @PostMapping("/health/check")
+  public ResponseDto healthCheck(@RequestBody HealthCheckRequest request) {
+
+    // 받아온 결과값을 저장하고 유지한다.
+    chatService.healthCheck(
+        request.getAddress(),
+        request.getConnectionCount(),
+        request.getHeartBeatTime()
+    );
+
+    // 가장 연결 수가 적은 서버를 리턴해주는 로직도 구현해야 한다.
+
+    return new ResponseDto(true, null, "헬스 체크 완료", null);
+
+  }
 
   /**
    * 새로운 채팅방 생성 API.

--- a/src/main/java/com/flab/football/controller/request/HealthCheckRequest.java
+++ b/src/main/java/com/flab/football/controller/request/HealthCheckRequest.java
@@ -1,0 +1,19 @@
+package com.flab.football.controller.request;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HealthCheckRequest {
+
+  private String address;
+  private int connectionCount;
+  private LocalDateTime heartBeatTime;
+
+}

--- a/src/main/java/com/flab/football/controller/response/data/FindPossibleConnectServerResponse.java
+++ b/src/main/java/com/flab/football/controller/response/data/FindPossibleConnectServerResponse.java
@@ -1,0 +1,14 @@
+package com.flab.football.controller.response.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindPossibleConnectServerResponse {
+
+  private String address;
+
+}

--- a/src/main/java/com/flab/football/service/chat/ChatService.java
+++ b/src/main/java/com/flab/football/service/chat/ChatService.java
@@ -3,6 +3,7 @@ package com.flab.football.service.chat;
 import com.flab.football.domain.Channel;
 import com.flab.football.domain.Message;
 import com.flab.football.domain.Participant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatService {
@@ -18,5 +19,7 @@ public interface ChatService {
   List<Participant> findParticipantsByChannelId(int channelId);
 
   List<Integer> findMessageReceivers(int channelId);
+
+  void healthCheck(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
 
 }

--- a/src/main/java/com/flab/football/service/chat/ChatService.java
+++ b/src/main/java/com/flab/football/service/chat/ChatService.java
@@ -21,6 +21,6 @@ public interface ChatService {
 
   void healthCheck(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
 
-  void connectUserToWebSocket();
+  String findPossibleConnectServerAddress();
 
 }

--- a/src/main/java/com/flab/football/service/chat/ChatService.java
+++ b/src/main/java/com/flab/football/service/chat/ChatService.java
@@ -1,7 +1,6 @@
 package com.flab.football.service.chat;
 
 import com.flab.football.domain.Channel;
-import com.flab.football.domain.Message;
 import com.flab.football.domain.Participant;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,5 +20,7 @@ public interface ChatService {
   List<Integer> findMessageReceivers(int channelId);
 
   void healthCheck(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
+
+  void connectUserToWebSocket();
 
 }

--- a/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
@@ -179,7 +179,9 @@ public class ChatServiceImpl implements ChatService {
 
     redisService.setServerInfo(address, connectionCount, lastHeartBeatTime);
 
-    log.info(address + " connectionCount = {}", redisService.getConnectionCount(address));
+    log.info("connectionCount = {}", redisService.getAddress(address));
+
+    log.info("connectionCount = {}", redisService.getConnectionCount(address));
 
     log.info(address + " LastHeartBeatTime = {}", redisService.getLastHeartBeatTime(address));
 

--- a/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
@@ -19,11 +19,9 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * 채팅 관련 비즈니스 로직이 선언된 서비스 구현체.
@@ -39,8 +37,6 @@ public class ChatServiceImpl implements ChatService {
   private final ChatPushService chatPushService;
 
   private final RedisService redisService;
-
-  private final RestTemplate restTemplate;
 
   private final ChannelRepository channelRepository;
 
@@ -183,7 +179,8 @@ public class ChatServiceImpl implements ChatService {
   }
 
   @Override
-  public void connectUserToWebSocket() {
+  @Transactional
+  public String findPossibleConnectServerAddress() {
 
     Set<String> serverInfoKeySet = redisService.getServerInfoKeySet();
 
@@ -211,9 +208,7 @@ public class ChatServiceImpl implements ChatService {
 
     }
 
-    String uri = "http://" + address + "/ws/connect";
-
-    restTemplate.getForEntity(uri, ResponseEntity.class);
+    return "ws://" + address + "/ws/chat";
 
   }
 

--- a/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
@@ -9,13 +9,18 @@ import com.flab.football.repository.chat.ChannelRepository;
 import com.flab.football.repository.chat.MessageRepository;
 import com.flab.football.repository.chat.ParticipantRepository;
 import com.flab.football.service.chat.command.PushMessageCommand;
+import com.flab.football.service.redis.RedisService;
 import com.flab.football.service.user.UserService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +36,8 @@ public class ChatServiceImpl implements ChatService {
   private final UserService userService;
 
   private final ChatPushService chatPushService;
+
+  private final RedisService redisService;
 
   private final ChannelRepository channelRepository;
 
@@ -161,6 +168,20 @@ public class ChatServiceImpl implements ChatService {
     }
 
     return userIdList;
+
+  }
+
+  @Override
+  @Transactional
+  public void healthCheck(String address, int connectionCount, LocalDateTime lastHeartBeatTime) {
+
+    // 10초 동안 결과가 안넘어오면 서버가 죽은 걸로 판단하도록 로직 구현
+
+    redisService.setServerInfo(address, connectionCount, lastHeartBeatTime);
+
+    log.info(address + " connectionCount = {}", redisService.getConnectionCount(address));
+
+    log.info(address + " LastHeartBeatTime = {}", redisService.getLastHeartBeatTime(address));
 
   }
 

--- a/src/main/java/com/flab/football/service/redis/RedisService.java
+++ b/src/main/java/com/flab/football/service/redis/RedisService.java
@@ -13,6 +13,8 @@ public interface RedisService {
 
   void setServerInfo(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
 
+  void deleteServerInfo(String key);
+
   Set<String> getServerInfoKeySet();
 
   String getAddress(String key);

--- a/src/main/java/com/flab/football/service/redis/RedisService.java
+++ b/src/main/java/com/flab/football/service/redis/RedisService.java
@@ -1,7 +1,6 @@
 package com.flab.football.service.redis;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 public interface RedisService {
 
@@ -14,6 +13,8 @@ public interface RedisService {
   void setServerInfo(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
 
   Object getServerInfo(String address);
+
+  String getAddress(String address);
 
   Integer getConnectionCount(String address);
 

--- a/src/main/java/com/flab/football/service/redis/RedisService.java
+++ b/src/main/java/com/flab/football/service/redis/RedisService.java
@@ -1,6 +1,7 @@
 package com.flab.football.service.redis;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 public interface RedisService {
 
@@ -12,12 +13,12 @@ public interface RedisService {
 
   void setServerInfo(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
 
-  Object getServerInfo(String address);
+  Set<String> getServerInfoKeySet();
 
-  String getAddress(String address);
+  String getAddress(String key);
 
-  Integer getConnectionCount(String address);
+  Integer getConnectionCount(String key);
 
-  LocalDateTime getLastHeartBeatTime(String address);
+  LocalDateTime getLastHeartBeatTime(String key);
 
 }

--- a/src/main/java/com/flab/football/service/redis/RedisService.java
+++ b/src/main/java/com/flab/football/service/redis/RedisService.java
@@ -1,11 +1,22 @@
 package com.flab.football.service.redis;
 
+import java.time.LocalDateTime;
+import java.util.Map;
+
 public interface RedisService {
 
-  void setSession(String userId, Object session);
+  void setSession(String userId, String session);
 
   void deleteSession(String userId);
 
-  Object getSession(String userId);
+  String getSession(String userId);
+
+  void setServerInfo(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
+
+  Object getServerInfo(String address);
+
+  Integer getConnectionCount(String address);
+
+  LocalDateTime getLastHeartBeatTime(String address);
 
 }

--- a/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
+++ b/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
@@ -68,6 +68,13 @@ public class RedisServiceImpl implements RedisService {
   }
 
   @Override
+  public void deleteServerInfo(String key) {
+
+    redisTemplate.delete(key);
+
+  }
+
+  @Override
   public String getAddress(String key) {
 
     return (String) redisTemplate.opsForHash().get(key, WebSocketUtils.ADDRESS);

--- a/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
+++ b/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
@@ -2,6 +2,7 @@ package com.flab.football.service.redis;
 
 import com.flab.football.websocket.util.WebSocketUtils;
 import java.time.LocalDateTime;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;
@@ -50,38 +51,40 @@ public class RedisServiceImpl implements RedisService {
 
     hashOperations.put(key, WebSocketUtils.LAST_HEARTBEAT_TIME, lastHeartBeatTime);
 
-  }
+    log.info("address = {}", getAddress(key));
 
-  @Override
-  public Object getServerInfo(String address) {
+    log.info("connectionCount = {}", getConnectionCount(key));
 
-    HashOperations<String, String, Object> hashOperations = redisTemplate.opsForHash();
-
-    return hashOperations.entries(address);
+    log.info("LastHeartBeatTime = {}", getLastHeartBeatTime(key));
 
   }
 
   @Override
-  public String getAddress(String address) {
+  public Set<String> getServerInfoKeySet() {
 
-    return (String) redisTemplate.opsForHash()
-        .get(WebSocketUtils.PREFIX_SERVER + address, WebSocketUtils.ADDRESS);
+    return redisTemplate.opsForHash()
+        .getOperations()
+        .keys(WebSocketUtils.PREFIX_SERVER + "*");
+  }
+
+  @Override
+  public String getAddress(String key) {
+
+    return (String) redisTemplate.opsForHash().get(key, WebSocketUtils.ADDRESS);
 
   }
 
   @Override
-  public Integer getConnectionCount(String address) {
+  public Integer getConnectionCount(String key) {
 
-    return (Integer) redisTemplate.opsForHash()
-        .get(WebSocketUtils.PREFIX_SERVER + address, WebSocketUtils.CONNECTION_COUNT);
+    return (Integer) redisTemplate.opsForHash().get(key, WebSocketUtils.CONNECTION_COUNT);
 
   }
 
   @Override
-  public LocalDateTime getLastHeartBeatTime(String address) {
+  public LocalDateTime getLastHeartBeatTime(String key) {
 
-    return (LocalDateTime) redisTemplate.opsForHash()
-        .get(WebSocketUtils.PREFIX_SERVER + address, WebSocketUtils.LAST_HEARTBEAT_TIME);
+    return (LocalDateTime) redisTemplate.opsForHash().get(key, WebSocketUtils.LAST_HEARTBEAT_TIME);
 
   }
 

--- a/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
+++ b/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
@@ -1,7 +1,10 @@
 package com.flab.football.service.redis;
 
+import java.time.LocalDateTime;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +17,7 @@ public class RedisServiceImpl implements RedisService {
 
 
   @Override
-  public void setSession(String userId, Object session) {
+  public void setSession(String userId, String session) {
 
     redisTemplate.opsForValue().set(userId, session);
 
@@ -28,9 +31,43 @@ public class RedisServiceImpl implements RedisService {
   }
 
   @Override
-  public Object getSession(String userId) {
+  public String getSession(String userId) {
 
-    return redisTemplate.opsForValue().get(userId);
+    return (String) redisTemplate.opsForValue().get(userId);
+
+  }
+
+  @Override
+  public void setServerInfo(String address, int connectionCount, LocalDateTime lastHeartBeatTime) {
+
+    HashOperations<String, String, Object> hashOperations = redisTemplate.opsForHash();
+
+    hashOperations.put(address, "connectionCount", connectionCount);
+
+    hashOperations.put(address, "lastHeartBeatTime", lastHeartBeatTime);
+
+  }
+
+  @Override
+  public Object getServerInfo(String address) {
+
+    HashOperations<String, String, Object> hashOperations = redisTemplate.opsForHash();
+
+    return hashOperations.entries(address);
+
+  }
+
+  @Override
+  public Integer getConnectionCount(String address) {
+
+    return (Integer) redisTemplate.opsForHash().get(address, "connectionCount");
+
+  }
+
+  @Override
+  public LocalDateTime getLastHeartBeatTime(String address) {
+
+    return (LocalDateTime) redisTemplate.opsForHash().get(address, "lastHeartBeatTime");
 
   }
 }

--- a/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
+++ b/src/main/java/com/flab/football/service/redis/RedisServiceImpl.java
@@ -1,7 +1,7 @@
 package com.flab.football.service.redis;
 
+import com.flab.football.websocket.util.WebSocketUtils;
 import java.time.LocalDateTime;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;
@@ -42,9 +42,13 @@ public class RedisServiceImpl implements RedisService {
 
     HashOperations<String, String, Object> hashOperations = redisTemplate.opsForHash();
 
-    hashOperations.put(address, "connectionCount", connectionCount);
+    String key = WebSocketUtils.PREFIX_SERVER + address;
 
-    hashOperations.put(address, "lastHeartBeatTime", lastHeartBeatTime);
+    hashOperations.put(key, WebSocketUtils.ADDRESS, address);
+
+    hashOperations.put(key, WebSocketUtils.CONNECTION_COUNT, connectionCount);
+
+    hashOperations.put(key, WebSocketUtils.LAST_HEARTBEAT_TIME, lastHeartBeatTime);
 
   }
 
@@ -58,16 +62,27 @@ public class RedisServiceImpl implements RedisService {
   }
 
   @Override
+  public String getAddress(String address) {
+
+    return (String) redisTemplate.opsForHash()
+        .get(WebSocketUtils.PREFIX_SERVER + address, WebSocketUtils.ADDRESS);
+
+  }
+
+  @Override
   public Integer getConnectionCount(String address) {
 
-    return (Integer) redisTemplate.opsForHash().get(address, "connectionCount");
+    return (Integer) redisTemplate.opsForHash()
+        .get(WebSocketUtils.PREFIX_SERVER + address, WebSocketUtils.CONNECTION_COUNT);
 
   }
 
   @Override
   public LocalDateTime getLastHeartBeatTime(String address) {
 
-    return (LocalDateTime) redisTemplate.opsForHash().get(address, "lastHeartBeatTime");
+    return (LocalDateTime) redisTemplate.opsForHash()
+        .get(WebSocketUtils.PREFIX_SERVER + address, WebSocketUtils.LAST_HEARTBEAT_TIME);
 
   }
+
 }

--- a/src/main/java/com/flab/football/websocket/config/WebSocketEtcConfig.java
+++ b/src/main/java/com/flab/football/websocket/config/WebSocketEtcConfig.java
@@ -1,6 +1,7 @@
 package com.flab.football.websocket.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.net.InetAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,7 +38,11 @@ public class WebSocketEtcConfig {
   @Bean
   public ObjectMapper objectMapper() {
 
-    return new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    objectMapper.registerModule(new JavaTimeModule());
+
+    return objectMapper;
 
   }
 

--- a/src/main/java/com/flab/football/websocket/conrtroller/WebSocketController.java
+++ b/src/main/java/com/flab/football/websocket/conrtroller/WebSocketController.java
@@ -1,18 +1,23 @@
 package com.flab.football.websocket.conrtroller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.football.controller.response.ResponseDto;
+import com.flab.football.websocket.conrtroller.request.HeartBeatRequest;
 import com.flab.football.websocket.conrtroller.request.SendMessageRequest;
+import com.flab.football.websocket.service.HeartBeatService;
 import com.flab.football.websocket.service.SessionService;
-import java.util.Map;
+import java.time.LocalDateTime;
+import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -26,9 +31,18 @@ import org.springframework.web.socket.WebSocketSession;
 @RequiredArgsConstructor
 public class WebSocketController {
 
+  private final HeartBeatService heartBeatService;
+
   private final SessionService sessionService;
 
   private final ObjectMapper objectMapper;
+
+  @Scheduled(fixedRate = 3000)
+  public void heartBeat() {
+
+    heartBeatService.sendHeartBeat();
+
+  }
 
   /**
    * 접속한 대상 회원에게 메세지 전송 API.

--- a/src/main/java/com/flab/football/websocket/conrtroller/WebSocketController.java
+++ b/src/main/java/com/flab/football/websocket/conrtroller/WebSocketController.java
@@ -1,23 +1,19 @@
 package com.flab.football.websocket.conrtroller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.flab.football.controller.response.ResponseDto;
-import com.flab.football.websocket.conrtroller.request.HeartBeatRequest;
 import com.flab.football.websocket.conrtroller.request.SendMessageRequest;
 import com.flab.football.websocket.service.HeartBeatService;
 import com.flab.football.websocket.service.SessionService;
-import java.time.LocalDateTime;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -41,6 +37,17 @@ public class WebSocketController {
   public void heartBeat() {
 
     heartBeatService.sendHeartBeat();
+
+  }
+
+  @GetMapping("/connect")
+  public ResponseEntity<HttpStatus> connectServer() {
+
+    log.info("OK");
+
+    // 웹소켓에 클라이언트를 연결시켜주는 메소드는 어떤 것이 있을지 고민해봐야 한다.
+
+    return new ResponseEntity<>(HttpStatus.OK);
 
   }
 

--- a/src/main/java/com/flab/football/websocket/conrtroller/WebSocketController.java
+++ b/src/main/java/com/flab/football/websocket/conrtroller/WebSocketController.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,21 +32,14 @@ public class WebSocketController {
 
   private final ObjectMapper objectMapper;
 
+  /**
+   * WebSocket 서버의 상태를 지속적으로 API 서버로 전송하는 heartBeat 메소드.
+   */
+
   @Scheduled(fixedRate = 3000)
   public void heartBeat() {
 
     heartBeatService.sendHeartBeat();
-
-  }
-
-  @GetMapping("/connect")
-  public ResponseEntity<HttpStatus> connectServer() {
-
-    log.info("OK");
-
-    // 웹소켓에 클라이언트를 연결시켜주는 메소드는 어떤 것이 있을지 고민해봐야 한다.
-
-    return new ResponseEntity<>(HttpStatus.OK);
 
   }
 

--- a/src/main/java/com/flab/football/websocket/conrtroller/request/HeartBeatRequest.java
+++ b/src/main/java/com/flab/football/websocket/conrtroller/request/HeartBeatRequest.java
@@ -1,0 +1,19 @@
+package com.flab.football.websocket.conrtroller.request;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HeartBeatRequest {
+
+  private String address;
+  private int connectionCount;
+  private LocalDateTime heartBeatTime;
+
+}

--- a/src/main/java/com/flab/football/websocket/service/HeartBeatService.java
+++ b/src/main/java/com/flab/football/websocket/service/HeartBeatService.java
@@ -1,0 +1,7 @@
+package com.flab.football.websocket.service;
+
+public interface HeartBeatService {
+
+  void sendHeartBeat();
+
+}

--- a/src/main/java/com/flab/football/websocket/service/HeartBeatServiceImpl.java
+++ b/src/main/java/com/flab/football/websocket/service/HeartBeatServiceImpl.java
@@ -1,0 +1,40 @@
+package com.flab.football.websocket.service;
+
+import com.flab.football.controller.response.ResponseDto;
+import com.flab.football.websocket.conrtroller.request.HeartBeatRequest;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class HeartBeatServiceImpl implements HeartBeatService {
+
+  private final RestTemplate restTemplate;
+
+  private final SessionService sessionService;
+
+  private final String address;
+
+
+  public void sendHeartBeat() {
+
+    HeartBeatRequest request = HeartBeatRequest.builder()
+        .address(address)
+        .connectionCount(sessionService.getSessionCount())
+        .heartBeatTime(LocalDateTime.now())
+        .build();
+
+    if (!address.contains("8080")) {
+
+      restTemplate.postForEntity(
+          "http://localhost:8080/chat/health/check",
+          request,
+          ResponseDto.class
+      );
+
+    }
+  }
+
+}

--- a/src/main/java/com/flab/football/websocket/service/SessionService.java
+++ b/src/main/java/com/flab/football/websocket/service/SessionService.java
@@ -10,4 +10,6 @@ public interface SessionService {
 
   WebSocketSession findSessionByUserId(int userId);
 
+  int getSessionCount();
+
 }

--- a/src/main/java/com/flab/football/websocket/service/SessionServiceImpl.java
+++ b/src/main/java/com/flab/football/websocket/service/SessionServiceImpl.java
@@ -34,4 +34,11 @@ public class SessionServiceImpl implements SessionService {
 
   }
 
+  @Override
+  public int getSessionCount() {
+
+    return sessions.size();
+
+  }
+
 }

--- a/src/main/java/com/flab/football/websocket/util/WebSocketUtils.java
+++ b/src/main/java/com/flab/football/websocket/util/WebSocketUtils.java
@@ -3,5 +3,10 @@ package com.flab.football.websocket.util;
 public class WebSocketUtils {
 
   public static final String PREFIX_KEY = "user::v1::";
+  public static final String PREFIX_SERVER = "server::v1::";
+  public static final String ADDRESS = "address";
+  public static final String CONNECTION_COUNT = "connectionCount";
+  public static final String LAST_HEARTBEAT_TIME = "lastHeartBeatTime";
+
 
 }


### PR DESCRIPTION
* WebSocketController.heartBeat() 메소드 구현
  - @Scheduled 사용
  - 3초에 한번씩 서버 상태 확인

* SessionService.getSessionCount() 메소드 구현
  - 세션에 연결된 사용자 수 확인

* ChatController.healthCheck() 메소드 구현
  - 웹 소켓 서버로부터 일정 시간에 한번씩 HeartBeat 결과를 받아온다.

* ObjectMapper 에 registerModule 추가
  - LocalDateTime의 직렬화를 위해 추가

* HeartBeatService 인터페이스 및 구현 클래스 생성
  - sendHeartBeat() 메소드 구현

* ChatService.healthCheck() 구현
  - 웹 소켓 서버로부터 호출되는 메소드
  - 넘어온 reqeust 객체를 가지고 redis에 hash 형태로 저장

* RedisService 에 서버정보 관련 메소드 구현