### PR TITLE
웹소켓 서버 연결 요청 API 리팩토링

### DIFF
--- a/src/main/java/com/flab/football/controller/ChatController.java
+++ b/src/main/java/com/flab/football/controller/ChatController.java
@@ -5,7 +5,7 @@ import com.flab.football.controller.request.HealthCheckRequest;
 import com.flab.football.controller.request.InviteParticipantsRequest;
 import com.flab.football.controller.request.SendMessageRequest;
 import com.flab.football.controller.response.ResponseDto;
-import com.flab.football.controller.response.data.FindPossibleConnectServerResponse;
+import com.flab.football.controller.response.data.FindPrimaryWebSocketServerAddressData;
 import com.flab.football.service.chat.ChatService;
 import com.flab.football.service.security.SecurityService;
 import javax.validation.Valid;
@@ -52,18 +52,18 @@ public class ChatController {
   }
 
   /**
-   * 새로운 사용자를 웹소켓 서버 주소를 탐색하는 API.
+   * 새로운 사용자가 접근할 최적 환경의 웹소켓 서버 주소를 탐색하는 API.
    *
    */
 
   @GetMapping("/connect")
-  public ResponseDto findPossibleConnectServerAddress() {
+  public ResponseDto findPrimaryWebSocketServerAddress() {
 
-    String address = chatService.findPossibleConnectServerAddress();
+    String address = chatService.findPrimaryWebSocketServerAddress();
 
     return new ResponseDto(
         true,
-        new FindPossibleConnectServerResponse(address),
+        new FindPrimaryWebSocketServerAddressData(address),
         "웹 소켓 주소 전송 완료.",
         null
     );

--- a/src/main/java/com/flab/football/controller/response/data/FindPrimaryWebSocketServerAddressData.java
+++ b/src/main/java/com/flab/football/controller/response/data/FindPrimaryWebSocketServerAddressData.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class FindPossibleConnectServerResponse {
+public class FindPrimaryWebSocketServerAddressData {
 
   private String address;
 

--- a/src/main/java/com/flab/football/service/chat/ChatPushServiceImpl.java
+++ b/src/main/java/com/flab/football/service/chat/ChatPushServiceImpl.java
@@ -24,7 +24,9 @@ public class ChatPushServiceImpl implements ChatPushService {
   @Override
   public void pushMessage(PushMessageCommand command) {
 
-    String address = (String) redisService.getSession(PREFIX_KEY + command.getReceiveUserId());
+    String address = redisService.getWebSocketSession(
+        PREFIX_KEY + command.getReceiveUserId()
+    );
 
     if (address == null) {
 

--- a/src/main/java/com/flab/football/service/chat/ChatService.java
+++ b/src/main/java/com/flab/football/service/chat/ChatService.java
@@ -21,6 +21,6 @@ public interface ChatService {
 
   void healthCheck(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
 
-  String findPossibleConnectServerAddress();
+  String findPrimaryWebSocketServerAddress();
 
 }

--- a/src/main/java/com/flab/football/service/redis/RedisService.java
+++ b/src/main/java/com/flab/football/service/redis/RedisService.java
@@ -1,26 +1,30 @@
 package com.flab.football.service.redis;
 
 import java.time.LocalDateTime;
-import java.util.Set;
+import org.springframework.data.redis.core.Cursor;
 
 public interface RedisService {
 
-  void setSession(String userId, String session);
+  void setWebSocketSession(String userId, String session);
 
-  void deleteSession(String userId);
+  void deleteWebSocketSession(String userId);
 
-  String getSession(String userId);
+  String getWebSocketSession(String userId);
 
-  void setServerInfo(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
+  void setWebSocketServerInfo(String address, int connectionCount, LocalDateTime lastHeartBeatTime);
 
-  void deleteServerInfo(String key);
+  void deleteWebSocketServerInfo(String key);
 
-  Set<String> getServerInfoKeySet();
+  Cursor<String> scanWebSocketServerKey();
 
-  String getAddress(String key);
+  String getWebSocketAddress(String key);
 
-  Integer getConnectionCount(String key);
+  Integer getWebSocketConnectionCount(String key);
 
-  LocalDateTime getLastHeartBeatTime(String key);
+  LocalDateTime getWebSocketLastHeartBeatTime(String key);
+
+  void setPrimaryWebSocketServerKeys();
+
+  String getPrimaryWebSocketServerKey();
 
 }

--- a/src/main/java/com/flab/football/service/security/jwt/JwtFilter.java
+++ b/src/main/java/com/flab/football/service/security/jwt/JwtFilter.java
@@ -43,9 +43,9 @@ public class JwtFilter implements Filter {
 
     if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
 
-      Authentication authentication = tokenProvider.getAuthentication(jwt);
+      Authentication authentication = tokenProvider.getAuthentication(jwt); // 이 부분에 DTO 클래스를 추가하면 된다? 굳이 userDetails와 관련 없어도 된다!!
 
-      SecurityContextHolder.getContext().setAuthentication(authentication);
+      SecurityContextHolder.getContext().setAuthentication(authentication); // 넘겨주는 것!
 
       log.debug("Security Context에 '{}' 인증 정보 저장, uri: {}", authentication.getName(), requestURI);
 

--- a/src/main/java/com/flab/football/websocket/handler/ChatHandler.java
+++ b/src/main/java/com/flab/football/websocket/handler/ChatHandler.java
@@ -44,7 +44,7 @@ public class ChatHandler extends TextWebSocketHandler {
     int userId = getCurrentUserId(session);
 
     // userId 와 웹소켓 서버 정보를 redis 에 저장
-    redisService.setSession(PREFIX_KEY + userId, address);
+    redisService.setWebSocketSession(PREFIX_KEY + userId, address);
 
     // 웹소켓 서버 내 메모리에 session 객체를 저장
     sessionService.saveSession(userId, session);
@@ -63,7 +63,7 @@ public class ChatHandler extends TextWebSocketHandler {
     int userId = getCurrentUserId(session);
 
     // userId 와 웹소켓 서버 정보를 redis 에서 삭제
-    redisService.deleteSession(PREFIX_KEY + userId);
+    redisService.deleteWebSocketSession(PREFIX_KEY + userId);
 
     // 웹소켓 서버 내 메모리에 session 객체를 삭제
     sessionService.removeSession(userId, session);

--- a/src/main/java/com/flab/football/websocket/util/WebSocketUtils.java
+++ b/src/main/java/com/flab/football/websocket/util/WebSocketUtils.java
@@ -7,6 +7,6 @@ public class WebSocketUtils {
   public static final String ADDRESS = "address";
   public static final String CONNECTION_COUNT = "connectionCount";
   public static final String LAST_HEARTBEAT_TIME = "lastHeartBeatTime";
-
+  public static final String Z_SET_KEY = "zSetKey";
 
 }


### PR DESCRIPTION
클라이언트의 요청에 따라 최우선 웹소켓 서버 주소를 응답해주는 API를 리팩토링해봤습니다!

이전에 문제가 되었던 keys() 메소드를 scan()으로 변경함으로써 한번에 모든 키값을 탐색하는 방법이 아닌 지정한 count 수만큼만 탐색하도록 변경했습니다! 이를 통해 하나의 커맨드로 인해 많은 시간을 소요해 다른 요청을 처리하지 못하는 문제점을 줄여보고자 했습니다! 

또한 Sorted Set 자료구조를 활용해 서버별 연결된 사용자의 수에 따라 자동 정렬된 set을 따로 저장해두도록 변경했습니다! 이를 통해 최우선 서버를 찾기 위해 모은 서버 정보들을 접근할 필요없이 하나의 ZSet 자료구조에만 접근하는 방법으로 같은 문제를 해결해봤습니다!