### PR TITLE
엔티티 연관관계 설정 변경

### DIFF
--- a/src/main/java/com/flab/football/domain/Match.java
+++ b/src/main/java/com/flab/football/domain/Match.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -93,16 +94,11 @@ public class Match {
   @Column(name = "limit_gender")
   private LimitGender gender;
 
-  @Column(name = "stadium_id", updatable = false)
+  @Column(name = "stadium_id", insertable = false, updatable = false)
   private int stadiumId;
 
   @OneToOne(cascade = CascadeType.ALL)
-  @JoinColumn(
-      name = "stadium_id",
-      referencedColumnName = "id",
-      insertable = false,
-      updatable = false
-  )
+  @JoinColumn(name = "stadium_id", referencedColumnName = "id")
   private Stadium stadium;
 
   @OneToOne(mappedBy = "match", cascade = CascadeType.ALL)
@@ -128,21 +124,19 @@ public class Match {
     @Column(name = "id")
     private int id;
 
-    @Column(name = "user_id", updatable = false)
-    private int userId;
+    @Column(name = "match_id", insertable = false, updatable = false)
+    private int matchId;
 
-    @OneToOne
-    @JoinColumn(
-        name = "user_id",
-        referencedColumnName = "id",
-        insertable = false,
-        updatable = false
-    )
-    private User user;
+    @Column(name = "user_id", insertable = false, updatable = false)
+    private int userId;
 
     @OneToOne
     @JoinColumn(name = "match_id", referencedColumnName = "id")
     private Match match;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
 
   }
 
@@ -163,18 +157,18 @@ public class Match {
     @Column(name = "id")
     private int id;
 
-    @Column(name = "match_id", updatable = false)
+    @Column(name = "match_id", insertable = false, updatable = false)
     private int matchId;
 
-    @Column(name = "user_id", updatable = false)
+    @Column(name = "user_id", insertable = false, updatable = false)
     private int userId;
 
     @ManyToOne
-    @JoinColumn(name = "match_id", referencedColumnName = "id", insertable = false, updatable = false)
+    @JoinColumn(name = "match_id", referencedColumnName = "id")
     private Match match;
 
     @OneToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "id", insertable = false, updatable = false)
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
   }
 

--- a/src/main/java/com/flab/football/domain/Match.java
+++ b/src/main/java/com/flab/football/domain/Match.java
@@ -93,8 +93,16 @@ public class Match {
   @Column(name = "limit_gender")
   private LimitGender gender;
 
+  @Column(name = "stadium_id", updatable = false)
+  private int stadiumId;
+
   @OneToOne(cascade = CascadeType.ALL)
-  @JoinColumn(name = "stadium_id", referencedColumnName = "id")
+  @JoinColumn(
+      name = "stadium_id",
+      referencedColumnName = "id",
+      insertable = false,
+      updatable = false
+  )
   private Stadium stadium;
 
   @OneToOne(mappedBy = "match", cascade = CascadeType.ALL)
@@ -120,13 +128,22 @@ public class Match {
     @Column(name = "id")
     private int id;
 
+    @Column(name = "user_id", updatable = false)
+    private int userId;
+
+    @OneToOne
+    @JoinColumn(
+        name = "user_id",
+        referencedColumnName = "id",
+        insertable = false,
+        updatable = false
+    )
+    private User user;
+
     @OneToOne
     @JoinColumn(name = "match_id", referencedColumnName = "id")
     private Match match;
 
-    @OneToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
-    private User user;
   }
 
   /**
@@ -146,12 +163,18 @@ public class Match {
     @Column(name = "id")
     private int id;
 
+    @Column(name = "match_id", updatable = false)
+    private int matchId;
+
+    @Column(name = "user_id", updatable = false)
+    private int userId;
+
     @ManyToOne
-    @JoinColumn(name = "match_id", referencedColumnName = "id")
+    @JoinColumn(name = "match_id", referencedColumnName = "id", insertable = false, updatable = false)
     private Match match;
 
     @OneToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    @JoinColumn(name = "user_id", referencedColumnName = "id", insertable = false, updatable = false)
     private User user;
   }
 

--- a/src/main/java/com/flab/football/domain/Message.java
+++ b/src/main/java/com/flab/football/domain/Message.java
@@ -53,28 +53,18 @@ public class Message {
   @Column(name = "create_at")
   private LocalDateTime createAt;
 
-  @Column(name = "channel_id", updatable = false)
+  @Column(name = "channel_id", insertable = false, updatable = false)
   private int channelId;
 
-  @Column(name = "user_id", updatable = false)
+  @Column(name = "user_id", insertable = false, updatable = false)
   private int userId;
 
   @ManyToOne(cascade = CascadeType.ALL)
-  @JoinColumn(
-      name = "channel_id",
-      referencedColumnName = "id",
-      insertable = false,
-      updatable = false
-  )
+  @JoinColumn(name = "channel_id", referencedColumnName = "id")
   private Channel channel;
 
   @OneToOne(cascade = CascadeType.ALL)
-  @JoinColumn(
-      name = "user_id",
-      referencedColumnName = "id",
-      insertable = false,
-      updatable = false
-  )
+  @JoinColumn(name = "user_id", referencedColumnName = "id")
   private User user;
 
 }

--- a/src/main/java/com/flab/football/domain/Message.java
+++ b/src/main/java/com/flab/football/domain/Message.java
@@ -53,12 +53,28 @@ public class Message {
   @Column(name = "create_at")
   private LocalDateTime createAt;
 
-  @OneToOne(cascade = CascadeType.ALL)
-  @JoinColumn(name = "user_id", referencedColumnName = "id")
-  private User user;
+  @Column(name = "channel_id", updatable = false)
+  private int channelId;
+
+  @Column(name = "user_id", updatable = false)
+  private int userId;
 
   @ManyToOne(cascade = CascadeType.ALL)
-  @JoinColumn(name = "channel_id", referencedColumnName = "id")
+  @JoinColumn(
+      name = "channel_id",
+      referencedColumnName = "id",
+      insertable = false,
+      updatable = false
+  )
   private Channel channel;
+
+  @OneToOne(cascade = CascadeType.ALL)
+  @JoinColumn(
+      name = "user_id",
+      referencedColumnName = "id",
+      insertable = false,
+      updatable = false
+  )
+  private User user;
 
 }

--- a/src/main/java/com/flab/football/domain/Participant.java
+++ b/src/main/java/com/flab/football/domain/Participant.java
@@ -35,20 +35,18 @@ public class Participant {
   @Column(name = "id")
   private int id;
 
-  @Column(name = "channel_id", updatable = false)
+  @Column(name = "channel_id", insertable = false, updatable = false)
   private int channelId;
 
-  @Column(name = "user_id", updatable = false)
+  @Column(name = "user_id", insertable = false, updatable = false)
   private int userId;
 
   @ManyToOne
-  @JoinColumn(name = "channel_id", referencedColumnName = "id",
-              insertable = false, updatable = false)
+  @JoinColumn(name = "channel_id", referencedColumnName = "id")
   private Channel channel;
 
   @OneToOne
-  @JoinColumn(name = "user_id", referencedColumnName = "id",
-              insertable = false, updatable = false)
+  @JoinColumn(name = "user_id", referencedColumnName = "id")
   private User user;
 
   /**

--- a/src/main/java/com/flab/football/domain/Participant.java
+++ b/src/main/java/com/flab/football/domain/Participant.java
@@ -35,10 +35,10 @@ public class Participant {
   @Column(name = "id")
   private int id;
 
-  @Column(name = "channel_id")
+  @Column(name = "channel_id", updatable = false)
   private int channelId;
 
-  @Column(name = "user_id")
+  @Column(name = "user_id", updatable = false)
   private int userId;
 
   @ManyToOne

--- a/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/flab/football/service/chat/ChatServiceImpl.java
@@ -4,13 +4,11 @@ import com.flab.football.domain.Channel;
 import com.flab.football.domain.Message;
 import com.flab.football.domain.Message.Type;
 import com.flab.football.domain.Participant;
-import com.flab.football.domain.User;
 import com.flab.football.repository.chat.ChannelRepository;
 import com.flab.football.repository.chat.MessageRepository;
 import com.flab.football.repository.chat.ParticipantRepository;
 import com.flab.football.service.chat.command.PushMessageCommand;
 import com.flab.football.service.redis.RedisService;
-import com.flab.football.service.user.UserService;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -30,8 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService {
-
-  private final UserService userService;
 
   private final ChatPushService chatPushService;
 
@@ -80,19 +76,13 @@ public class ChatServiceImpl implements ChatService {
   @Transactional
   public void sendMessage(int channelId, int sendUserId, String content) {
 
-    Channel channel = findChannelById(channelId);
-
-    User user = userService.findById(sendUserId);
-
     Message message = Message.builder()
         .type(Type.MESSAGE)
         .content(content)
         .createAt(LocalDateTime.now())
+        .channelId(channelId)
+        .userId(sendUserId)
         .build();
-
-    message.setUser(user);
-
-    message.setChannel(channel);
 
     messageRepository.save(message);
 

--- a/src/main/java/com/flab/football/service/match/MatchServiceImpl.java
+++ b/src/main/java/com/flab/football/service/match/MatchServiceImpl.java
@@ -2,7 +2,12 @@ package com.flab.football.service.match;
 
 import com.flab.football.domain.Match;
 import com.flab.football.domain.Match.Manager;
+import com.flab.football.domain.Stadium;
+import com.flab.football.domain.User;
+import com.flab.football.exception.NotExistStadiumException;
 import com.flab.football.repository.match.MatchRepository;
+import com.flab.football.repository.stadium.StadiumRepository;
+import com.flab.football.repository.user.UserRepository;
 import com.flab.football.service.match.command.CreateMatchCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +22,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MatchServiceImpl implements MatchService {
 
+  private final UserRepository userRepository;
+
+  private final StadiumRepository stadiumRepository;
+
   private final MatchRepository matchRepository;
 
   /**
@@ -25,6 +34,12 @@ public class MatchServiceImpl implements MatchService {
 
   @Override
   public void createMatch(CreateMatchCommand command) {
+
+    User user = userRepository.findById(command.getUserId())
+        .orElseThrow(() -> new RuntimeException("회원정보가 존재하지 않습니다."));
+
+    Stadium stadium = stadiumRepository.findById(command.getStadiumId())
+        .orElseThrow(() -> new NotExistStadiumException("구장 정보가 존재하지 않습니다."));
 
     Match match = Match.builder()
         .startTime(command.getStartTime())
@@ -35,14 +50,14 @@ public class MatchServiceImpl implements MatchService {
         .shoes(command.getShoes())
         .level(command.getLevel())
         .gender(command.getGender())
-        .stadiumId(command.getStadiumId())
+        .stadium(stadium)
         .build();
 
     Match.Manager manager = Manager.builder()
-        .userId(command.getUserId())
+        .user(user)
         .build();
 
-    manager.setMatch(match); // 매치 - 매니저 양방향 관계 설정
+    manager.setMatch(match); // 매니저 - 매치 양방향 관계 설정
 
     match.setManager(manager); // 매치 - 매니저 양방향 관계 설정
 
@@ -53,9 +68,15 @@ public class MatchServiceImpl implements MatchService {
   @Override
   public void applyToParticipant(int userId, int matchId) {
 
+    Match match = matchRepository.findById(matchId)
+        .orElseThrow(() -> new RuntimeException("매치 정보가 존재하지 않습니다."));
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new RuntimeException("회원정보가 존재하지 않습니다."));
+
     Match.Member member = Match.Member.builder()
-        .userId(userId)
-        .matchId(matchId)
+        .match(match)
+        .user(user)
         .build();
 
     matchRepository.save(member);


### PR DESCRIPTION
* 외래키를 가진 객체의 연관관계 객체 설정에 insertable, updatable 값을 false로 변경

* 외래키를 직접 저장할 외래키 필드 추가(updatable은 false로 지정)

* 변경된 엔티티 객체를 save하는 로직에서 연관객체 조회 로직 제거(불필요한 select문 발생 지점 삭제)