### PR TITLE
N+1 쿼리 문제 해결 추가 작업

### DIFF
--- a/football-api-server/build.gradle
+++ b/football-api-server/build.gradle
@@ -17,6 +17,9 @@ dependencies {
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.projectlombok:lombok:1.18.26'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/football-api-server/src/main/java/com/flab/football/domain/Channel.java
+++ b/football-api-server/src/main/java/com/flab/football/domain/Channel.java
@@ -1,14 +1,8 @@
 package com.flab.football.domain;
 
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,7 +29,7 @@ public class Channel {
   @Column(name = "name")
   private String name;
 
-  @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "channel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   private List<Participant> participants;
 
   /**

--- a/football-api-server/src/main/java/com/flab/football/domain/Participant.java
+++ b/football-api-server/src/main/java/com/flab/football/domain/Participant.java
@@ -2,15 +2,7 @@ package com.flab.football.domain;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,17 +27,18 @@ public class Participant {
   @Column(name = "id")
   private int id;
 
+  // 외래키 값을 그대로 받아오는 형태
   @Column(name = "channel_id", insertable = false, updatable = false)
   private int channelId;
 
   @Column(name = "user_id", insertable = false, updatable = false)
   private int userId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "channel_id", referencedColumnName = "id")
   private Channel channel;
 
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", referencedColumnName = "id")
   private User user;
 

--- a/football-api-server/src/main/java/com/flab/football/repository/chat/ChannelRepository.java
+++ b/football-api-server/src/main/java/com/flab/football/repository/chat/ChannelRepository.java
@@ -3,13 +3,12 @@ package com.flab.football.repository.chat;
 import com.flab.football.domain.Channel;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChannelRepository extends JpaRepository<Channel, Integer> {
-
-  Channel save(Channel channel);
-
-  Optional<Channel> findById(int channelId);
+  @Query(value = "select c from Channel c join fetch c.participants where c.id = :channelId")
+  Optional<Channel> findByIdFetchJoin(int channelId);
 
 }

--- a/football-api-server/src/main/java/com/flab/football/repository/chat/ParticipantRepository.java
+++ b/football-api-server/src/main/java/com/flab/football/repository/chat/ParticipantRepository.java
@@ -19,8 +19,9 @@ public interface ParticipantRepository extends JpaRepository<Participant, Intege
 
   Optional<Participant> findById(Participant participant);
 
-  @EntityGraph(attributePaths = "user")
-  @Query("SELECT p FROM Participant p WHERE p.channel.id = :channelId")
+  @Query("SELECT p FROM Participant p join fetch p.user WHERE p.channel.id = :channelId")
+  List<Participant> findAllByChannelIdFetchJoin(@Param(value = "channelId") int channelId);
+
   List<Participant> findAllByChannelId(@Param(value = "channelId") int channelId);
 
   @Query("SELECT p.userId FROM Participant p WHERE p.channel.id = :channelId")

--- a/football-api-server/src/test/java/com/flab/football/service/chat/ChatServiceImplTest.java
+++ b/football-api-server/src/test/java/com/flab/football/service/chat/ChatServiceImplTest.java
@@ -1,0 +1,34 @@
+package com.flab.football.service.chat;
+
+import com.flab.football.ApiApplication;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ApiApplication.class)
+@ActiveProfiles("local")
+public class ChatServiceImplTest {
+
+    @Autowired
+    private ChatService chatService;
+
+    @Test
+    @DisplayName("테스트 1")
+    public void test1() {
+        int channelId = 1;
+        int sendUserId = 12;
+        String content = "hello world!";
+        chatService.sendMessage(channelId, sendUserId, content);
+    }
+
+}


### PR DESCRIPTION
- 지연 로딩을 통해 간단히 해결할 수 있는 방법으로 추가 리팩토링 진행
- 다만 추후에 fetch join을 사용할 경우와 그렇지 않을 경우를 대비해 두 방식의 조회 메소드를 분리해 구현
- 테스트 코드 작성